### PR TITLE
fix listing modules

### DIFF
--- a/proxymodules/size.py
+++ b/proxymodules/size.py
@@ -25,7 +25,7 @@ class Module:
         return data
 
 
-   def help(self):
+    def help(self):
         h = '\tverbose: override the global verbosity setting'
         return h
 

--- a/proxymodules/size.py
+++ b/proxymodules/size.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2
-from distutils.utils import strtobool
+from distutils.util import strtobool
 
 class Module:
     def __init__(self, incoming=False, verbose=False, options=None):


### PR DESCRIPTION
Currently it is not possible to list modules.

```
./tcpproxy.py --list
hexdump - Print a hexdump of the received data
http_ok - Prepend HTTP response header
http_post - Prepend HTTP header
http_strip - Remove HTTP header from data
javaxml - Serialization or deserialization of Java objects (needs jython)
log - Log data in the module chain. Use in addition to general logging (-l/--log).
removegzip - Replace gzip in the list of accepted encodings in a HTTP request with booo.
replace - Replace text by using regular expressions
Traceback (most recent call last):
  File "./tcpproxy.py", line 394, in <module>
    main()
  File "./tcpproxy.py", line 324, in main
    list_modules()
  File "./tcpproxy.py", line 122, in list_modules
    __import__('proxymodules.' + module)
  File "/usr/src/tcpproxy/proxymodules/size.py", line 28
    def help(self):
                  ^
IndentationError: unindent does not match any outer indentation level
```

This changes fix the indention level and renames the module `distutils.utils` to `distutils.util`.