### PR TITLE
Disable verification of server cert

### DIFF
--- a/tcpproxy.py
+++ b/tcpproxy.py
@@ -227,6 +227,8 @@ def enable_ssl(args, remote_socket, local_socket):
 
     try:
         ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
         if args.client_certificate and args.client_key:
             ctx.load_cert_chain(certfile=args.client_certificate,
                                 keyfile=args.client_key,


### PR DESCRIPTION
I'm not sure when this happened, because surely we would have noticed this before, but I couldn't connect to a target service with an unverifiable certificate. I suspect it's [this](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.check_hostname):

> Changed in version 3.7: verify_mode is now automatically changed to CERT_REQUIRED when hostname checking is enabled and verify_mode is CERT_NONE. Previously the same operation would have failed with a ValueError.

This PR disables certificate verification.

Clearly we don't really care about certificate validation. If you disagree, we could create a new parameter `-k` like in `curl`, to disable certificate validation by request and enable it by default.