### PR TITLE
Removed connection testing for MQTT

### DIFF
--- a/proxymodules/mqtt.py
+++ b/proxymodules/mqtt.py
@@ -34,7 +34,7 @@ class Module:
                 except ValueError:
                     print(f'port: invalid port {options["port"]}, using default {self.port}')
             if 'topic' in options.keys():
-                self.topic = options['topic']
+                self.topic = options['topic'].strip()
             if 'hex' in options.keys():
                 try:
                     self.hex = bool(strtobool(options['hex']))
@@ -51,8 +51,7 @@ class Module:
 
     def execute(self, data):
         if self.mqtt is not None:
-            if not self.mqtt.is_connected():
-                self.mqtt.reconnect()
+
             if self.hex is True:
                 self.mqtt.publish(self.topic, data.hex())
             else:


### PR DESCRIPTION
Hello, thanks for your great work on tcpproxy! I had to implement a small fix for the mqtt plugin, as more recent versions of paho_mqtt don't have the is_connected option, it seems. Attempting to run the mqtt module otherwise results in an exception being thrown. Hopefully this helps!