### PR TITLE
Add delay packet feature + fix source ip default behavior

### DIFF
--- a/proxymodules/delay.py
+++ b/proxymodules/delay.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import os.path as path
+import time
+
+
+class Module:
+    def __init__(self, incoming=False, verbose=False, options=None):
+        # extract the file name from __file__. __file__ is proxymodules/name.py
+        self.name = path.splitext(path.basename(__file__))[0]
+        self.description = 'Set delay in passing through the packet, used for simulating various network conditions'
+        self.incoming = incoming  # incoming means module is on -im chain
+        self.seconds = None
+        if options is not None:
+            if 'seconds' in options.keys():
+                self.seconds = float(options['seconds'])
+
+    def execute(self, data):
+        if self.seconds:
+            time.sleep(self.seconds)
+
+        return data
+
+    def help(self):
+        h = '\tseconds: number of seconds you want the packet to be delayed'
+        return h
+
+
+if __name__ == '__main__':
+    print('This module is not supposed to be executed alone!')

--- a/tcpproxy.py
+++ b/tcpproxy.py
@@ -44,10 +44,10 @@ def parse_args():
                         default=8080, help='port to listen on')
 
     parser.add_argument('-si', '--sourceip', dest='source_ip',
-                        default='0.0.0.0', help='IP address the other end will see')
+                        help='IP address the other end will see')
 
     parser.add_argument('-sp', '--sourceport', dest='source_port', type=int,
-                        default=8080, help='source port the other end will see')
+                        help='source port the other end will see')
 
     parser.add_argument('-pi', '--proxy-ip', dest='proxy_ip', default=None,
                         help='IP address/host name of proxy')


### PR DESCRIPTION
The source ip binding I submitted earlier should be made optional and not added by default. So we removed the default from argparse. 

Adding a delay module so we can test some network scenario for an application where the packets arriving are delayed / dropped (if you were to close the proxy before the end of delay feature).