### PR TITLE
Added new module to replace hexadecimal data in TCP packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ javaxml - Serialization or deserialization of Java objects (needs jython)
 log - Log data in the module chain. Use in addition to general logging (-l/--log).
 removegzip - Replace gzip in the list of accepted encodings in a HTTP request with booo.
 replace - Replace text on the fly by using regular expressions in a file or as module parameters
+hexreplace - Replace hex data in tcp packets
 size - Print the size of the data passed to the module
 size404 - Change HTTP responses of a certain size to 404.
 textdump - Simply print the received data as text

--- a/proxymodules/hexreplace.py
+++ b/proxymodules/hexreplace.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+import os
+import re
+
+
+class Module:
+    def __init__(self, incoming=False, verbose=False, options=None):
+        # extract the file name from __file__. __file__ is proxymodules/name.py
+        self.name = os.path.splitext(os.path.basename(__file__))[0]
+        self.description = 'Replace hex data on the fly defining search and replace-pairs in a file or as module parameters'
+        self.verbose = verbose
+        self.search = None
+        self.replace = None
+        self.filename = None
+        self.separator = ':'
+        self.len = 16
+
+        if options is not None:
+            if 'search' in options.keys():
+                search = bytes.fromhex(options['search'])
+            if 'replace' in options.keys():
+                replace = bytes.fromhex(options['replace'])
+            if 'file' in options.keys():
+                self.filename = options['file']
+                try:
+                    open(self.filename)
+                except IOError as ioe:
+                    print("Error opening %s: %s" % (self.filename, ioe.strerror))
+                    self.filename = None
+            if 'separator' in options.keys():
+                self.separator = options['separator']
+
+        self.pairs = []  # list of (search, replace) tuples
+        if search is not None and replace is not None:
+            self.pairs.append((search, replace))
+
+        if self.filename is not None:
+            for line in open(self.filename).readlines():
+                try:
+                    search, replace = line.split(self.separator, 1)
+                    self.pairs.append((bytes.fromhex(search.strip()), bytes.fromhex(replace.strip())))
+                except ValueError:
+                    # line does not contain separator and will be ignored
+                    pass
+
+    def hexdump(self, data):
+        result = []
+        digits = 2
+        for i in range(0, len(data), self.len):
+            s = data[i:i + self.len]
+            hexa = ' '.join(['%0*X' % (digits, x) for x in s])
+            text = ''.join([chr(x) if 0x20 <= x < 0x7F else '.' for x in s])
+            result.append("%04X   %-*s   %s" % (i, self.len * (digits + 1), hexa, text))
+        print("\n".join(result))
+
+    def execute(self, data):
+        #self.hexdump(data)
+        print(f"Incoming packet with size {len(data)}:")
+        for search, replace in self.pairs:
+            #print(f"{search} -> {replace}")
+            if search in data:
+                print("########## data found ###########")
+                print("[Before:]")
+                self.hexdump(data)
+                data = data.replace(search, replace)
+                print("[After:]")
+                self.hexdump(data)
+        return data
+
+    def help(self):
+        h = '\tsearch: hex string (i.e. "deadbeef") to search for\n'
+        h += ('\treplace: hex string the search string should be replaced with\n')
+        h += ('\tfile: file containing search:replace pairs, one per line\n')
+        h += ('\tseparator: define a custom search:replace separator in the file, e.g. search#replace\n')
+        h += ('\n\tUse at least file or search and replace (or both).\n')
+        return h
+
+
+if __name__ == '__main__':
+    print('This module is not supposed to be executed alone!')


### PR DESCRIPTION
With this module, plain hexadecimal data can be replaced in a TCP packet. By employing
```
./tcpproxy.py ... -im hexreplace:search=deadbeef:replace=00000000
```
the hexadecimal values `\xDE\xAD\xBE\xEF` are replaced by `\x00\x00\x00\x00`. This could be useful to modify a binary stream on the go.